### PR TITLE
syntax: add git commit and rebase modes

### DIFF
--- a/misc/syntax
+++ b/misc/syntax
@@ -284,3 +284,17 @@ i=haskell
 
 /*.go
 i=golang
+
+# git commit message mode
+//# Please enter (the|a) commit message (for your changes|to explain)
+c3=^#
+c1,1=^# On branch ([^[:space:]]+)
+c2,1=^#[[:space:]]+(copied|deleted|modified|new file|renamed\
+ |typechange|unknown|unmerged):
+c2,1=^(Conflicts):
+c3,1=\W('[^']+?')\W
+
+# git rebase (interactive) mode
+//# Rebase .\{1,30\} onto .
+c3=^#
+c2,1=^(p(?:ick)|r(?:eword)|e(?:dit)|s(?:quash)|f(?:ixup)|x|exec)[[:space:]]


### PR DESCRIPTION
Some additional modes mainly to highlight some important information. Technically the modes could also be selected by matching the filename, like (.git/)COMMIT_EDITMSG  but I've only made it match by content at this time.
