### PR TITLE
Allow embedding the config files into the binary.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,13 @@ if test "x$enable_file_locks" = xno; then
    AC_DEFINE([DISABLE_FILE_LOCKS], 1, [define if file locking does not work or is not desirable])
 fi
 
+AC_ARG_ENABLE(embed-datadir, [  --enable-embed-datadir   embed contents of PKGDATADIR in binary  ],
+   [enable_embed_datadir=$enableval],[enable_embed_datadir=no])
+if test "x$enable_embed_datadir" = xyes; then
+  AC_DEFINE([EMBED_DATADIR], 1, [define to embed PKGDATADIR in binary])
+fi
+AM_CONDITIONAL(EMBED_DATADIR, test "x$enable_embed_datadir" = xyes)
+
 test -z "$CXX"	     && DEFAULT_CXX=yes
 test -z "$CFLAGS"    && DEFAULT_CFLAGS=yes
 test -z "$CXXFLAGS"  && DEFAULT_CXXFLAGS=yes

--- a/misc/.gitignore
+++ b/misc/.gitignore
@@ -1,0 +1,2 @@
+files2embed
+datadir

--- a/misc/Makefile.am
+++ b/misc/Makefile.am
@@ -11,13 +11,25 @@ syntax = syntax syntax.d/ada syntax.d/as syntax.d/awk syntax.d/c++-comment	\
  syntax.d/verilog syntax.d/javascript syntax.d/ocaml syntax.d/haskell		\
  syntax.d/golang
 
+if !EMBED_DATADIR
 nobase_pkgdata_DATA = $(colors) $(keymaps) $(mainmenus) $(syntax)
 pkgdata_SCRIPTS = help
 EXTRA_DIST = $(nobase_pkgdata_DATA) $(pkgdata_SCRIPTS)
+endif
 
 colors: ../src/le
 	../src/le --dump-colors > $@
 keymap: ../src/le
 	../src/le --dump-keymap > $@
 
-CLEANFILES = colors keymap
+noinst_PROGRAMS = files2embed
+
+files2embed_SOURCES = files2embed.c
+
+datadir: $(colors) $(keymaps) mainmenu $(syntax) | files2embed
+	./files2embed $^ > $@
+
+datadir.o: datadir
+	$(LD) -r -o $@ -z noexecstack -b binary $<
+
+CLEANFILES = colors keymap datadir

--- a/misc/files2embed.c
+++ b/misc/files2embed.c
@@ -1,0 +1,56 @@
+/* tool for compiling files into a binary lump suitable for inclusion */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* qsort wrapper of strcmp */
+int qstrcmp(const void* a, const void* b) {
+   return strcmp(*((char**) a), *((char**) b));
+}
+
+/* entry point */
+int main(int argc, char **argv) {
+
+   /* show usage */
+   if(argc < 2) {
+      fprintf(stderr, "Usage: %s INFILES... > OUTFILE\n", argv[0]);
+      return 1;
+   }
+
+   /* sort args */
+   size_t count = argc - 1;
+   qsort(&argv[1], count, sizeof(void *), &qstrcmp);
+   
+   /* table of contents */
+   struct __attribute__((__packed__)) {
+      size_t name;
+      size_t data;
+   } toc[count];
+   
+   /* concat the files */
+   size_t pos = 0;
+   int i;
+   char buf[1024];
+   for(i = 0; i < count; i++) {
+      toc[i].name = pos;
+      pos += fwrite(argv[i + 1], 1, strlen(argv[i + 1]) + 1, stdout);
+      FILE *fh = fopen(argv[i + 1], "r");
+      fseek(fh, 0, SEEK_END);
+      size_t s = ftell(fh);
+      toc[i].data = pos;
+      fseek(fh, 0, SEEK_SET);
+      pos += fwrite(&s, 1, sizeof(s), stdout);
+      while((s = fread(buf, 1, sizeof(buf), fh)) > 0)
+	pos += fwrite(buf, 1, s, stdout);
+      fclose(fh);
+   }
+
+   /* output the table of contents */
+   fwrite(toc, sizeof(*toc), count, stdout);
+   
+   /* output entry count */
+   fwrite(&count, sizeof(count), 1, stdout);
+   
+   /* finished */
+   return 0;
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,14 +9,29 @@ le_SOURCES = about.cc block.cc calc.cc chset.cc cmd.cc color.cc edit.cc\
  menu.h menu1.h options.h rus.h screen.h search.h textpoin.h user.h\
  window.h highli.cc highli.h clipbrd.cc clipbrd.h keynames.h keynames.cc\
  mouse.h mouse.cc getch.h format.h colormnu.cc colormnu.h bm.cc bm.h\
- mb.cc mb.h undo.cc undo.h regex.c regex.h wcwidth.c wcwidth1.c
+ mb.cc mb.h undo.cc undo.h regex.c regex.h wcwidth.c wcwidth1.c efopen.c\
+ efopen.h
 
 GNULIB = $(top_builddir)/lib/libgnu.a
 
-le_DEPENDENCIES = $(GNULIB)
-le_LDADD = $(GNULIB) $(CURSES_LIBS) $(LIBINTL) $(LIBSOCKET)
+if EMBED_DATADIR
+le_EMBED_DATADIR = ../misc/datadir.o le_hlp.o
+endif
+
+le_DEPENDENCIES = $(GNULIB) $(le_EMBED_DATADIR)
+le_LDADD = $(GNULIB) $(CURSES_LIBS) $(LIBINTL) $(LIBSOCKET) $(le_EMBED_DATADIR)
 
 INCLUDES = -I$(top_builddir)/lib -I$(top_srcdir)/lib $(CURSES_INCLUDES)
 
+if !EMBED_DATADIR
 EXTRA_DIST = le.hlp
 pkgdata_DATA = le.hlp
+endif
+
+../misc/datadir.o:
+	cd $(@D) && $(MAKE) $(@F)
+
+le_hlp.o: le.hlp
+	$(LD) -r -o $@ -z noexecstack -b binary $<
+
+CLEANFILES = $(le_EMBED_DATADIR)

--- a/src/cmd.cc
+++ b/src/cmd.cc
@@ -32,7 +32,11 @@ char    Shell  [256]="exec $SHELL";
 char    Make   [256]="exec make";
 char    Run    [256]="exec make run";
 char    Compile[256]="exec make \"$FNAME.o\"";
+# ifdef EMBED_DATADIR
+char    HelpCmd[256]="man \"$WORD\"";
+# else
 char    HelpCmd[256]="exec "PKGDATADIR"/help";
+# endif
 #else
 char    Shell  [256]="command";
 char    Make   [256]="make";

--- a/src/colormnu.cc
+++ b/src/colormnu.cc
@@ -23,7 +23,7 @@
 #include "edit.h"
 #include "colormnu.h"
 #include "options.h"
-#include <alloca.h>
+#include "efopen.h"
 
 void ColorsSaveToFile(const char *f)
 {
@@ -34,26 +34,36 @@ void ColorsSaveToFile(const char *f)
 static const char *const colors_file="/.le/colors";
 void ColorsSave()
 {
-   char *f=(char*)alloca(strlen(HOME)+strlen(colors_file)+1);
+   char f[strlen(HOME)+strlen(colors_file)+1];
    sprintf(f,"%s%s",HOME,colors_file);
    ColorsSaveToFile(f);
 }
 
 void ColorsSaveForTerminal()
 {
-   char *f=(char*)alloca(strlen(HOME)+strlen(colors_file)+1+strlen(TERM)+1);
+   char f[strlen(HOME)+strlen(colors_file)+1+strlen(TERM)+1];
    sprintf(f,"%s%s-%s",HOME,colors_file,TERM);
    ColorsSaveToFile(f);
 }
 
-void LoadColor(const char *f)
+void LoadColor(const char *name)
 {
-   if(access(f,R_OK)==-1)
+#ifdef EMBED_DATADIR
+   char fn[strlen(name)+1];
+   sprintf(fn,"%s",name);
+   FILE *f=efopen(fn,"r");
+#else
+   char fn[strlen(PKGDATADIR)+1+strlen(name)+1];
+   sprintf(fn,"%s/%s",PKGDATADIR,name);
+   FILE *f=fopen(fn,"r");
+#endif
+   if(!f)
    {
-      FError(f);
+      FError(fn);
       return;
    }
-   ReadConfFromFile(f,colors,false);
+   ReadConfFromOpenFile(f,colors);
+   fclose(f);
    ParseColors();
    init_attrs();
    clearok(stdscr,1);
@@ -73,21 +83,21 @@ void LoadColorDefault()
 
 void LoadColorDefaultBG()
 {
-   LoadColor(PKGDATADIR"/colors-defbg");
+   LoadColor("colors-defbg");
 }
 void LoadColorBlue()
 {
-   LoadColor(PKGDATADIR"/colors-blue");
+   LoadColor("colors-blue");
 }
 void LoadColorBlack()
 {
-   LoadColor(PKGDATADIR"/colors-black");
+   LoadColor("colors-black");
 }
 void LoadColorWhite()
 {
-   LoadColor(PKGDATADIR"/colors-white");
+   LoadColor("colors-white");
 }
 void LoadColorGreen()
 {
-   LoadColor(PKGDATADIR"/colors-green");
+   LoadColor("colors-green");
 }

--- a/src/efopen.c
+++ b/src/efopen.c
@@ -1,0 +1,54 @@
+/* efopen is like fopen, but using an embedded set of files */
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "efopen.h"
+
+extern char _binary_datadir_start;
+extern char _binary_datadir_end;
+
+typedef struct __attribute__((__packed__)) {
+   size_t name;
+   size_t data;
+} toc_t;
+
+static toc_t *tocv = NULL;
+static size_t tocc;
+
+/* comparator for toc_t */
+static int toccmp(const void* k, const void* a) {
+   return strcmp((char*)k, &_binary_datadir_start + ((toc_t*)a)->name);
+}
+
+/* lazy init */
+static void init(void) {
+   tocc = *(size_t*)(&_binary_datadir_end - sizeof(tocc));
+   tocv = (toc_t*)(&_binary_datadir_end - sizeof(tocc) - tocc * sizeof(toc_t));
+}
+
+extern FILE *efopen(const char *path, const char *mode) {
+
+   /* lazy init */
+   if(tocv == NULL) init();
+
+   /* find matching entry in table of contents */
+   toc_t *entry = bsearch(path, tocv, tocc, sizeof(toc_t), &toccmp);
+   if(entry == NULL) {
+      errno = ENOENT;
+      return NULL;
+   }
+
+   /* only allow read-only access */
+   if(strcmp("r", mode) != 0) {
+      errno = EPERM;
+      return NULL;
+   }
+
+   /* create filehandle to the relevant embedded data */
+   size_t *size = (size_t*)(&_binary_datadir_start + entry->data);
+   void *data = size + 1;
+   return fmemopen(data, *size, "r");
+
+}

--- a/src/efopen.h
+++ b/src/efopen.h
@@ -1,0 +1,14 @@
+/* efopen is like fopen, but using an embedded set of files */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#include <stdio.h>
+
+extern FILE *efopen(const char *path, const char *mode);
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/help.cc
+++ b/src/help.cc
@@ -23,6 +23,11 @@
 #include <string.h>
 #include <stdlib.h>
 
+#ifdef EMBED_DATADIR
+extern char _binary_le_hlp_start;
+extern char _binary_le_hlp_size;
+#endif
+
 #if 0
 void  Help(char ***h,char *title)
 {
@@ -96,7 +101,11 @@ static char *LoadHelp(const char *tag)
    if(!help)
       return 0;
    help[0]=0;
+#ifdef EMBED_DATADIR
+   FILE *hf=fmemopen(&_binary_le_hlp_start,(size_t)&_binary_le_hlp_size,"r");
+#else
    FILE *hf=fopen(PKGDATADIR "/le.hlp","r");
+#endif
    if(!hf)
    {
       free(help);

--- a/src/menu1.cc
+++ b/src/menu1.cc
@@ -24,6 +24,7 @@
 #include "keymap.h"
 #include "clipbrd.h"
 #include "block.h"
+#include "efopen.h"
 
 extern   Menu1 MainMenu[];
 
@@ -499,24 +500,27 @@ extern void fskip(FILE*);
 
 void LoadMainMenu()
 {
-   FILE *f;
-   char fn[1024];
    char func[256];
    char str[256];
    int mi=0;
    int level=0;
 
-   sprintf(fn,"%s/.le/mainmenu",HOME);
-
-   f=fopen(fn,"r");
-   if(f)
-      goto read_it;
-
-   f=fopen(PKGDATADIR "/mainmenu","r");
-   if(f==0)
+   FILE *f=0;
+   if(!f)
+   {
+      char fn[strlen(HOME)+1+3+1+8+1];
+      sprintf(fn,"%s/.le/mainmenu",HOME);
+      f=fopen(fn,"r");
+   }
+#ifdef EMBED_DATADIR
+   if(!f) 
+      f=efopen("mainmenu", "r");
+#else
+   if(!f)
+      f=fopen(PKGDATADIR"/mainmenu","r");
+#endif
+   if(!f)
       return;
-
-read_it:
 
    if(m && free_m)
    {

--- a/src/options.h
+++ b/src/options.h
@@ -25,7 +25,7 @@ struct init
 
 void SaveConfToOpenFile(FILE *f,const struct init *init);
 void SaveConfToFile(const char *f,const struct init *init);
-void ReadConfFromFile(const char *file,const struct init *init,bool mine);
+void ReadConfFromOpenFile(FILE *f,const struct init *init);
 
 void ColorsOpt();
 void ProgOpt();


### PR DESCRIPTION
The `--enable-embed-datadir` option to `./configure` will cause the config files from `/misc/` and `/src/le.hlp` to be embedded into the binary.  This is useful for creating a portable binary with minimal dependencies which can be copied to a user's home directory on a target system.  User overrides are still searched in `~/.le/`.
