### PR TITLE
add missing 'configmake' module to bootstrap

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -18,6 +18,7 @@
 
 # gnulib modules used by this package.
 gnulib_modules="
+  configmake
   alloca
   btowc
   fnmatch

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -182,3 +182,5 @@
 /limits.h
 /dup-safer-flag.c
 /fd-safer-flag.c
+/stat-time.c
+/stat-time.h

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -118,3 +118,6 @@
 /limits-h.m4
 /malloca.m4
 /open-cloexec.m4
+/fnmatch_h.m4
+/getpagesize.m4
+/stat-time.m4

--- a/m4/gnulib-cache.m4
+++ b/m4/gnulib-cache.m4
@@ -1,4 +1,4 @@
-# Copyright (C) 2002-2017 Free Software Foundation, Inc.
+# Copyright (C) 2002-2018 Free Software Foundation, Inc.
 #
 # This file is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,7 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this file.  If not, see <http://www.gnu.org/licenses/>.
+# along with this file.  If not, see <https://www.gnu.org/licenses/>.
 #
 # As a special exception to the GNU General Public License,
 # this file may be distributed as part of a program that
@@ -27,13 +27,39 @@
 
 
 # Specification in the form of a command-line invocation:
-#   gnulib-tool --import --local-dir=gl --lib=libgnu --source-base=lib --m4-base=m4 --doc-base=doc --tests-base=tests --aux-dir=build-aux --no-conditional-dependencies --no-libtool --macro-prefix=gl alloca btowc fnmatch ftruncate getcwd getopt-gnu git-version-gen mbswidth mkdir poll sockets strdup strerror strtol times
+# gnulib-tool --import --local-dir=gl \
+#  --lib=libgnu \
+#  --source-base=lib \
+#  --m4-base=m4 \
+#  --doc-base=doc \
+#  --tests-base=tests \
+#  --aux-dir=build-aux \
+#  --no-conditional-dependencies \
+#  --no-libtool \
+#  --macro-prefix=gl \
+#  alloca \
+#  btowc \
+#  configmake \
+#  fnmatch \
+#  ftruncate \
+#  getcwd \
+#  getopt-gnu \
+#  git-version-gen \
+#  mbswidth \
+#  mkdir \
+#  poll \
+#  sockets \
+#  strdup \
+#  strerror \
+#  strtol \
+#  times
 
 # Specification in the form of a few gnulib-tool.m4 macro invocations:
 gl_LOCAL_DIR([gl])
 gl_MODULES([
   alloca
   btowc
+  configmake
   fnmatch
   ftruncate
   getcwd


### PR DESCRIPTION
Александр, приветствую.

Первый коммит исправляет проблему = как минимум без этой правки `configmake.h` не генерируется gnulib в Fedora28. Соответственно не собирается.

Второй коммит - смотрите сами несколько он нужен. Это просто обновление файлов, которые уже внесены в git. Т.е. это изменения, которые я вижу локально в Fedora28 после исправления.

Спасибо за le.