### PR TITLE
Add missing syntax.d/{c,c++,puppet} files to Makefile.am install list

### DIFF
--- a/misc/Makefile.am
+++ b/misc/Makefile.am
@@ -9,7 +9,8 @@ syntax = syntax syntax.d/ada syntax.d/as syntax.d/awk syntax.d/c++-comment	\
  syntax.d/python syntax.d/sather syntax.d/shell syntax.d/snmp-mib		\
  syntax.d/sql syntax.d/tcl syntax.d/tex syntax.d/texinfo syntax.d/txt2tags	\
  syntax.d/verilog syntax.d/javascript syntax.d/ocaml syntax.d/haskell		\
- syntax.d/golang syntax.d/nroff syntax.d/pod syntax.d/markdown syntax.d/css
+ syntax.d/golang syntax.d/nroff syntax.d/pod syntax.d/markdown syntax.d/css	\
+ syntax.d/c syntax.d/c++ syntax.d/puppet
 
 nobase_pkgdata_DATA = $(colors) $(keymaps) $(mainmenus) $(syntax)
 pkgdata_SCRIPTS = help


### PR DESCRIPTION
Signed-off-by: Igor Zhbanov <izh1979@gmail.com>