### PR TITLE
Cmake: set default build type as Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
 project(le VERSION 1.16.8)
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
 add_subdirectory(doc)
 add_subdirectory(src)
 add_subdirectory(misc)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can use either auto-tools or cmake to build from sources.
 ```shell
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=Release ..
+    cmake ..
     make
     make install
 ```


### PR DESCRIPTION
By default, use the Release build type. When Debug build is required, use:
```
cmake -DCMAKE_BUILD_TYPE=Debug ..
```