### PR TITLE
Fix sprintf warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.7)
 
 execute_process(
     COMMAND gnulib/git-version-gen .tarball-version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 execute_process(
     COMMAND gnulib/git-version-gen .tarball-version

--- a/src/FindNcursesw.cmake
+++ b/src/FindNcursesw.cmake
@@ -99,7 +99,11 @@
 
 include(CheckLibraryExists)
 
+# On MacOS, also search for packages installed by Homebrew.
 find_library(CURSES_NCURSESW_LIBRARY NAMES ncursesw
+  PATHS
+    /usr/local/opt/ncurses/lib
+    /opt/homebrew/opt/ncurses/lib
   DOC "Path to libncursesw.so or .lib or .a")
 
 set(CURSES_USE_NCURSES FALSE)
@@ -159,8 +163,11 @@ if(CURSES_USE_NCURSESW)
   set(CURSES_FOUND ${NCURSESW_FOUND})
 
 else()
-  find_package(Curses)
+  find_package(Curses REQUIRED)
   set(NCURSESW_FOUND FALSE)
+  if(NCURSES_VERSION VERSION_LESS "6.0")
+    message(WARNING "This Curses version ${NCURSES_VERSION} may be broken. Please use NCurses 6.0 or later.")
+  endif()
 endif()
 
 # Report whether each possible header name exists in the include directory.

--- a/src/block.cc
+++ b/src/block.cc
@@ -369,7 +369,7 @@ void    Write()
       PipeBlock(BlockFile+1,/*IN*/FALSE,/*OUT*/TRUE);
       return;
    }
-   if(ChooseFileName(BlockFile)<0)
+   if(ChooseFileName(BlockFile,sizeof(BlockFile))<0)
       return;
    LoadHistory.Push();
 
@@ -468,7 +468,7 @@ int OptionallyConvertBlockNewLines(const char *bname)
    if(EolIs(EOL_DOS) && dos_nl*2<unix_nl)
    {
 //       SyncTextWin();
-      sprintf(msg,"The %s block looks like it is in UNIX format,\n"
+      snprintf(msg,sizeof(msg),"The %s block looks like it is in UNIX format,\n"
 		  "whereas the current text is in DOS format\n"
 		  "Do you wish to convert the block?",bname);
       switch(ReadMenuBox(ynMenu,HORIZ,msg,
@@ -486,7 +486,7 @@ int OptionallyConvertBlockNewLines(const char *bname)
    else if(EolIs(EOL_UNIX) && dos_nl*2>unix_nl)
    {
 //       SyncTextWin();
-      sprintf(msg,"The %s block looks like it is in DOS format,\n"
+      snprintf(msg,sizeof(msg),"The %s block looks like it is in DOS format,\n"
 		  "whereas the current text is in UNIX format\n"
 		  "Do you wish to convert the block?",bname);
       switch(ReadMenuBox(ynMenu,HORIZ,msg,
@@ -530,7 +530,7 @@ void    Read()
 	 goto after_read;
       return;
    }
-   if(ChooseFileName(BlockFile)<0)
+   if(ChooseFileName(BlockFile,sizeof(BlockFile))<0)
       return;
    LoadHistory.Push();
 
@@ -698,7 +698,7 @@ void   Indent()
    if(View || hide)
       return;
    if(is[0]==0)
-      sprintf(is,"%d",IndentSize);
+      snprintf(is,sizeof(is),"%d",IndentSize);
    if(getstring("Indent size: ",is,sizeof(is)-1,NULL,NULL,NULL)<1)
       return;
    if(sscanf(is,"%d",&i)==0 || i==0 || abs(i)>1024)
@@ -721,7 +721,7 @@ void   Unindent()
    if(View || hide)
       return;
    if(is[0]==0)
-      sprintf(is,"%d",IndentSize);
+      snprintf(is,sizeof(is),"%d",IndentSize);
    if(getstring("Unindent size: ",is,sizeof(is)-1,NULL,NULL,NULL)<1)
       return;
    if(sscanf(is,"%d",&i)==0 || i==0 || abs(i)>1024)

--- a/src/calc.cc
+++ b/src/calc.cc
@@ -349,11 +349,11 @@ const char *calc_value::to_string()
 {
    static char s[256];
    if(base==10)
-      sprintf(s,"%.28Lg",value);
+      snprintf(s,sizeof(s),"%.28Lg",value);
    else if(base==8)
-      sprintf(s,"%#llo",(long long)value);
+      snprintf(s,sizeof(s),"%#llo",(long long)value);
    else if(base==16)
-      sprintf(s,"0x%llX",(long long)value);
+      snprintf(s,sizeof(s),"0x%llX",(long long)value);
    else
       strcpy(s,"unsupported base");
    return s;

--- a/src/chset.cc
+++ b/src/chset.cc
@@ -95,7 +95,7 @@ void  edit_chset()
       SetAttr(NORMAL_TEXT_ATTR);
       Clear();
       if(curr<32)
-         sprintf(chstr,"^%c",curr+'@');
+         snprintf(chstr,sizeof(chstr),"^%c",curr+'@');
       else
       {
 #if USE_MULTIBYTE_CHARS
@@ -111,9 +111,9 @@ void  edit_chset()
 	 }
 	 else // note the following line
 #endif
-	    sprintf(chstr,"%c",curr);
+	    snprintf(chstr,sizeof(chstr),"%c",curr);
       }
-      sprintf(s,"The current character is '%s', %3d, 0%03o, 0x%02X",chstr,curr,curr,curr);
+      snprintf(s,sizeof(s),"The current character is '%s', %3d, 0%03o, 0x%02X",chstr,curr,curr,curr);
 
       PutStr(2,2,s);
       for(i=0; i<16; i++)
@@ -195,7 +195,7 @@ int  choose_ch()
       Clear();
 
       if(curr<32)
-         sprintf(chstr,"^%c",curr+'@');
+         snprintf(chstr,sizeof(chstr),"^%c",curr+'@');
       else
       {
 #if USE_MULTIBYTE_CHARS
@@ -211,9 +211,9 @@ int  choose_ch()
 	 }
 	 else // note the following line
 #endif
-	    sprintf(chstr,"%c",curr);
+	    snprintf(chstr,sizeof(chstr),"%c",curr);
       }
-      sprintf(s,"The current character is '%s', %3d, 0%03o, 0x%02X",chstr,curr,curr,curr);
+      snprintf(s,sizeof(s),"The current character is '%s', %3d, 0%03o, 0x%02X",chstr,curr,curr,curr);
 
       PutStr(2,2,s);
       for(i=0; i<16; i++)
@@ -294,7 +294,7 @@ wchar_t choose_wch()
 	 PutStr(FRIGHT-6,FDOWN," PgDn ");
 
       if(curr<32)
-         sprintf(chstr,"^%c",curr+'@');
+         snprintf(chstr,sizeof(chstr),"^%c",curr+'@');
       else
       {
 	 int w=wcwidth(curr);
@@ -305,7 +305,7 @@ wchar_t choose_wch()
 	    ch_len=0;
 	 chstr[ch_len+(w==0)]=0;
       }
-      sprintf(s,"The current character is '%s', 0x%04X",chstr,curr);
+      snprintf(s,sizeof(s),"The current character is '%s', 0x%04X",chstr,curr);
 
       PutStr(2,2,s);
       for(i=0; i<16; i++)

--- a/src/cmd.cc
+++ b/src/cmd.cc
@@ -107,7 +107,7 @@ void    cmd(const char *c,bool autosave,bool pauseafter)
     else
         *n='\0',*ext='\0';  /* there was no extension */
 #ifndef __MSDOS__
-    sprintf(cl,"FILE=\"%s\";FNAME=\"%s\";EXT=\"%s\";WORD=\"%s\";export WORD FILE EXT FNAME; %s",
+    snprintf(cl,sizeof(cl),"FILE=\"%s\";FNAME=\"%s\";EXT=\"%s\";WORD=\"%s\";export WORD FILE EXT FNAME; %s",
                 file,name,ext,GetWord(),c);
 #else
     {

--- a/src/color.cc
+++ b/src/color.cc
@@ -292,19 +292,19 @@ void  DescribeOneColor(char *const desc,const color *cp)
    {
       if(c.fg!=NO_COLOR && a->value.fg==c.fg)
       {
-	 sprintf(d,",%s",a->name);
+	 snprintf(d,sizeof(color_descriptions[0]),",%s",a->name);
 	 d+=strlen(d);
 	 c.fg=NO_COLOR;
       }
       if(c.bg!=NO_COLOR && a->value.bg==c.bg)
       {
-	 sprintf(d,",%s",a->name);
+	 snprintf(d,sizeof(color_descriptions[0]),",%s",a->name);
 	 d+=strlen(d);
 	 c.bg=NO_COLOR;
       }
       if(c.attr & a->value.attr)
       {
-	 sprintf(d,",%s",a->name);
+	 snprintf(d,sizeof(color_descriptions[0]),",%s",a->name);
 	 d+=strlen(d);
 	 c.attr&=~a->value.attr;
       }

--- a/src/colormnu.cc
+++ b/src/colormnu.cc
@@ -36,15 +36,17 @@ void ColorsSaveToFile(const char *f)
 static const char *const colors_file="/.le/colors";
 void ColorsSave()
 {
-   char *f=(char*)alloca(strlen(HOME)+strlen(colors_file)+1);
-   sprintf(f,"%s%s",HOME,colors_file);
+   unsigned nbytes=strlen(HOME)+strlen(colors_file)+1;
+   char *f=(char*)alloca(nbytes);
+   snprintf(f,nbytes,"%s%s",HOME,colors_file);
    ColorsSaveToFile(f);
 }
 
 void ColorsSaveForTerminal()
 {
-   char *f=(char*)alloca(strlen(HOME)+strlen(colors_file)+1+strlen(TERM)+1);
-   sprintf(f,"%s%s-%s",HOME,colors_file,TERM);
+   unsigned nbytes=strlen(HOME)+strlen(colors_file)+1+strlen(TERM)+1;
+   char *f=(char*)alloca(nbytes);
+   snprintf(f,nbytes,"%s%s-%s",HOME,colors_file,TERM);
    ColorsSaveToFile(f);
 }
 

--- a/src/edit.cc
+++ b/src/edit.cc
@@ -432,14 +432,15 @@ void    Initialize()
    initcalc();
 
 #ifndef MSDOS
-   char  *filename=(char*)alloca((strlen(HOME)|15)+17);
-   sprintf(filename,"%s/.le",HOME);
+   unsigned nbytes=(strlen(HOME)|15)+17;
+   char  *filename=(char*)alloca(nbytes);
+   snprintf(filename,nbytes,"%s/.le",HOME);
    mkdir(filename,0700);
    strcat(filename,"/tmp");
    mkdir(filename,0700);
-   sprintf(HstName,"%s/.le/history2",HOME);
+   snprintf(HstName,sizeof(HstName),"%s/.le/history2",HOME);
 #else
-   sprintf(HstName,"%s/le.hst",HOME);
+   snprintf(HstName,sizeof(HstName),"%s/le.hst",HOME);
 #endif
 
    InstallSignalHandlers();
@@ -779,7 +780,7 @@ int     main(int argc,char **argv)
       {
          ShowAbout();
          if(getstring("Load: ",newname,255,&LoadHistory,NULL,NULL)<1
-                                             || ChooseFileName(newname)<0)
+                                             || ChooseFileName(newname,sizeof(newname))<0)
             Terminate();
          HideAbout();
       }
@@ -788,7 +789,7 @@ int     main(int argc,char **argv)
    {
       for(; optind<argc; optind++)
          LoadHistory+=argv[optind];
-      sprintf(newname,"%.255s",argv[argc-1]);
+      snprintf(newname,sizeof(newname),"%.255s",argv[argc-1]);
    }
    if(newname[0] && file_check(newname)==ERR)
    {

--- a/src/editcalc.cc
+++ b/src/editcalc.cc
@@ -61,7 +61,7 @@ void  editcalc()
       {
 	 for(i=sp-1; i>=0; i--)
 	 {
-            sprintf(str, "%s%s", stack[i].to_string(), &" "[i==0]);
+            snprintf(str, sizeof(str), "%s%s", stack[i].to_string(), &" "[i==0]);
 	    InsertBlock(str,strlen(str));
 	    SetStdCol();
 	 }

--- a/src/file.cc
+++ b/src/file.cc
@@ -144,7 +144,7 @@ void  condense(char *filename)
 
 #ifdef MSDOS
    if(isalpha(filename[0]) && filename[1]==':')
-      sprintf(drive,"%.2s",filename);
+      snprintf(drive,sizeof(drive),"%.2s",filename);
 #endif
 
    filenamelen=strlen(filename);
@@ -175,7 +175,7 @@ void  condense(char *filename)
       return;
    }
 
-   sprintf(tmp,"%s/",drive);
+   snprintf(tmp,sizeof(tmp),"%s/",drive);
    if(stat(tmp,&st)!=-1)
    {
       root_dev=st.st_dev;
@@ -186,7 +186,7 @@ void  condense(char *filename)
       root_dev=
       root_ino=0;
    }
-   sprintf(tmp,"%s.",drive);
+   snprintf(tmp,sizeof(tmp),"%s.",drive);
    if(stat(tmp,&st)!=-1)
    {
       curr_dev=st.st_dev;
@@ -217,7 +217,7 @@ void  condense(char *filename)
          while(*scan && !isslash(*scan))
             *(store++)=*(scan++);
          *store=0;
-         sprintf(tmp,"%s%s",drive,newfilename);
+         snprintf(tmp,sizeof(tmp),"%s%s",drive,newfilename);
          if(stat(tmp,&st)!=-1)
          {
             for(i=0; i<currpointno; i++)
@@ -250,14 +250,14 @@ void  condense(char *filename)
       }
    }
    *store=0;
-   sprintf(filename,"%s%s",drive,newfilename);
+   snprintf(filename,sizeof(directory),"%s%s",drive,newfilename);
    free(newfilename);
    free(ino_scanned);
    free(dev_scanned);
    free(point);
 }
 
-int ChooseFileName(char *fn)
+int ChooseFileName(char *fn, unsigned fn_size)
 {
    char	    *a;
    static WIN *w=NULL;
@@ -275,7 +275,7 @@ int ChooseFileName(char *fn)
 
 #ifdef MSDOS
    if(isalpha(fn[0]) && fn[1]==':')
-      sprintf(drive,"%.2s",fn);
+      snprintf(drive,sizeof(drive),"%.2s",fn);
 #endif
 
    /* strip trailing slashes - they are not needed */
@@ -285,17 +285,17 @@ int ChooseFileName(char *fn)
    a=strrchr(fn,'/');
    if(a==NULL)
    {
-      sprintf(directory,"%s.",drive);
+      snprintf(directory,sizeof(directory),"%s.",drive);
       strcpy(filename,fn+strlen(drive));
    }
    else
    {
       if(a!=fn+strlen(drive))
       {
-         sprintf(directory,"%.*s",(int)(a-fn),fn);
+         snprintf(directory,sizeof(directory),"%.*s",(int)(a-fn),fn);
       }
       else
-         sprintf(directory,"%s/",drive);
+         snprintf(directory,sizeof(directory),"%s/",drive);
       strcpy(filename,a+1);
    }
 
@@ -306,7 +306,7 @@ int ChooseFileName(char *fn)
          ErrMsg("Path name is too long");
          return(-1);
       }
-      sprintf(str,"%s%s",HOME,directory+1);
+      snprintf(str,sizeof(str),"%s%s",HOME,directory+1);
       strcpy(directory,str);
    }
 
@@ -326,9 +326,9 @@ int ChooseFileName(char *fn)
          if(*a=='\\' && a[1])
             memmove(a,a+1,strlen(a));  /* delete backslashes */
       if(directory[strlen(directory)-1]=='/')
-         sprintf(fn,"%s%s",directory,filename);
+         snprintf(fn,fn_size,"%s%s",directory,filename);
       else
-         sprintf(fn,"%s/%s",directory,filename);
+         snprintf(fn,fn_size,"%s/%s",directory,filename);
       if(!strncmp(fn+strlen(drive),"./",2))
          memmove(fn+strlen(drive),fn+strlen(drive)+2,strlen(fn+strlen(drive)+2)+1);
       LoadHistory+=fn;
@@ -351,7 +351,7 @@ int ChooseFileName(char *fn)
       if((st.st_mode&S_IFMT)!=S_IFDIR)
       {
          char  msg[128];
-         sprintf(msg,"%.60s: not a directory",directory);
+         snprintf(msg,sizeof(msg),"%.60s: not a directory",directory);
          ErrMsg(msg);
          CloseWin();
          DestroyWin(w);
@@ -393,7 +393,7 @@ int ChooseFileName(char *fn)
             dirsize=i;
             break;
          }
-         sprintf(str,"%s/%s",directory,entry->d_name);
+         snprintf(str,sizeof(str),"%s/%s",directory,entry->d_name);
          if(stat(str,&(dir[i].st))==-1
          || ((dir[i].st.st_mode&S_IFMT)==S_IFREG && fnmatch(filename,entry->d_name,0)!=0)
          || ((dir[i].st.st_mode&S_IFMT)!=S_IFREG && (dir[i].st.st_mode&S_IFMT)!=S_IFDIR)
@@ -433,13 +433,13 @@ int ChooseFileName(char *fn)
             {
                l=strlen(dir[i].name);
                if(l>DIRSIZ)
-                  sprintf(str," %.*s..%-.*s",DIRSIZ/2-1,dir[i].name,
+                  snprintf(str,sizeof(str)," %.*s..%-.*s",DIRSIZ/2-1,dir[i].name,
                    DIRSIZ-(DIRSIZ/2)-1,dir[i].name+l-(DIRSIZ-(DIRSIZ/2)-1));
                else
-                  sprintf(str," %.*s",DIRSIZ,dir[i].name);
+                  snprintf(str,sizeof(str)," %.*s",DIRSIZ,dir[i].name);
                if((dir[i].st.st_mode&S_IFMT)==S_IFDIR)
                   strcat(str,"/");
-               sprintf(str1,"%-*.*s",DIRSIZ+2,DIRSIZ+2,str);
+               snprintf(str1,sizeof(str1),"%-*.*s",DIRSIZ+2,DIRSIZ+2,str);
                SetAttr(i==current?CURR_BUTTON_ATTR:DIALOGUE_WIN_ATTR);
                PutStr(x+1,y,str1);
             }
@@ -455,9 +455,9 @@ int ChooseFileName(char *fn)
             PutStr(FRIGHT-6,FDOWN," PgDn ");
 
 	 if(directory[strlen(directory)-1]=='/')
-	    sprintf(str,"%s%s - %s",directory,filename,dir[current].name);
+	    snprintf(str,sizeof(str),"%s%s - %s",directory,filename,dir[current].name);
 	 else
-	    sprintf(str,"%s/%s - %s",directory,filename,dir[current].name);
+	    snprintf(str,sizeof(str),"%s/%s - %s",directory,filename,dir[current].name);
 	 Message(str);
 
          action=GetNextAction();
@@ -522,9 +522,9 @@ int ChooseFileName(char *fn)
 
    LoadHistory-=HistoryLine(fn); /* delete the pattern from the history */
    if(directory[strlen(directory)-1]=='/')
-      sprintf(fn,"%s%s",directory,dir[current].name);
+      snprintf(fn,fn_size,"%s%s",directory,dir[current].name);
    else
-      sprintf(fn,"%s/%s",directory,dir[current].name);
+      snprintf(fn,fn_size,"%s/%s",directory,dir[current].name);
    char *fn_d=fn+strlen(drive);
    if(!strncmp(fn_d,"./",2))
       memmove(fn_d,fn_d+2,strlen(fn_d+1));

--- a/src/file.h
+++ b/src/file.h
@@ -21,4 +21,4 @@ const char *le_dirname(const char *);
 static inline char *le_basename(char *f) { return const_cast<char*>(le_basename(const_cast<const char*>(f))); }
 static inline char *le_dirname(char *f) { return const_cast<char*>(le_dirname(const_cast<const char*>(f))); }
 
-int     ChooseFileName(char *pattern);
+int ChooseFileName(char *pattern, unsigned nbytes);

--- a/src/frames.cc
+++ b/src/frames.cc
@@ -254,7 +254,7 @@ void    DrawFrames(void)
       ClearMessage();
       SyncTextWin();
       attrset(STATUS_LINE_ATTR->n_attr);
-      sprintf(sign," $%d",curr_frame);
+      snprintf(sign,sizeof(sign)," $%d",curr_frame);
       mvaddstr(StatusLineY,COLS-4,sign);
       SetCursor();
 

--- a/src/getch.cc
+++ b/src/getch.cc
@@ -217,7 +217,7 @@ int linux_process_key(int key)
    }
    if(code)
    {
-      sprintf(str,"\033[1;%d%c",xterm_shift,code);
+      snprintf(str,sizeof(str),"\033[1;%d%c",xterm_shift,code);
       return ungetstr(str);
    }
    code=0;
@@ -238,7 +238,7 @@ int linux_process_key(int key)
    }
    if(code)
    {
-      sprintf(str,"\033[%d;%d~",code,xterm_shift);
+      snprintf(str,sizeof(str),"\033[%d;%d~",code,xterm_shift);
       return ungetstr(str);
    }
 

--- a/src/highli.cc
+++ b/src/highli.cc
@@ -216,10 +216,11 @@ static FILE *open_syntax_d(const char *name)
 {
    if(name[0]!='/') {
       const char *base_dir="syntax.d";
-      char *fn=(char*)alloca(strlen(PKGDATADIR)+strlen(HOME)+1+strlen(base_dir)+1+strlen(name)+1);
-      sprintf(fn,"%s/.le/%s/%s",HOME,base_dir,name);
+      unsigned nbytes=strlen(PKGDATADIR)+strlen(HOME)+1+strlen(base_dir)+1+strlen(name)+1;
+      char *fn=(char*)alloca(nbytes);
+      snprintf(fn,nbytes,"%s/.le/%s/%s",HOME,base_dir,name);
       if(access(fn,R_OK)==-1)
-	 sprintf(fn,"%s/%s/%s",PKGDATADIR,base_dir,name);
+	 snprintf(fn,nbytes,"%s/%s/%s",PKGDATADIR,base_dir,name);
       name=fn;
    }
    return fopen(name,"r");
@@ -462,14 +463,17 @@ void InitHighlight()
       return;
 
    static const char base_fn[]="syntax";
-   char *fn1=(char*)alloca(strlen(PKGDATADIR)+1+strlen(base_fn)+1);
-   char *fn2=(char*)alloca(strlen(HOME)+1+3+1+ strlen(base_fn)+1);
-   char *fn3=(char*)alloca(4+strlen(base_fn)+1);
+   unsigned nbytes1=strlen(PKGDATADIR)+1+strlen(base_fn)+1;
+   unsigned nbytes2=strlen(HOME)+1+3+1+ strlen(base_fn)+1;
+   unsigned nbytes3=4+strlen(base_fn)+1;
+   char *fn1=(char*)alloca(nbytes1);
+   char *fn2=(char*)alloca(nbytes2);
+   char *fn3=(char*)alloca(nbytes3);
    char *fn;
 
-   sprintf(fn1,"%s/%s",PKGDATADIR,base_fn);
-   sprintf(fn2,"%s/.le/%s",HOME,base_fn);
-   sprintf(fn3,".le.%s",base_fn);
+   snprintf(fn1,nbytes1,"%s/%s",PKGDATADIR,base_fn);
+   snprintf(fn2,nbytes2,"%s/.le/%s",HOME,base_fn);
+   snprintf(fn3,nbytes3,".le.%s",base_fn);
 
    FILE *f=0;
    if(!f)

--- a/src/history.cc
+++ b/src/history.cc
@@ -306,7 +306,7 @@ InodeInfo::InodeInfo(const HistoryLine *f_line)
 const char *InodeInfo::to_string() const
 {
    static char s[80];
-   sprintf(s,"%ld,%ld,%ld,%ld,%ld,%ld,%ld",
+   snprintf(s,sizeof(s),"%ld,%ld,%ld,%ld,%ld,%ld,%ld",
          (long)inode,(long)device,(long)time,
          (long)size,(long)line,(long)col,
 	 (long)offset);

--- a/src/keymapfn.cc
+++ b/src/keymapfn.cc
@@ -34,19 +34,19 @@ void  EditorReadKeymap()
    char  filename[1024];
    FILE  *f;
 
-   sprintf(filename,"%s/.le/keymap-%s",HOME,TERM);
+   snprintf(filename,sizeof(filename),"%s/.le/keymap-%s",HOME,TERM);
    f=fopen(filename,"r");
    if(f==NULL)
    {
-      sprintf(filename,"%s/keymap-%s",PKGDATADIR,TERM);
+      snprintf(filename,sizeof(filename),"%s/keymap-%s",PKGDATADIR,TERM);
       f=fopen(filename,"r");
       if(f==NULL)
       {
-         sprintf(filename,"%s/.le/keymap",HOME);
+         snprintf(filename,sizeof(filename),"%s/.le/keymap",HOME);
          f=fopen(filename,"r");
          if(f==NULL)
          {
-            sprintf(filename,"%s/keymap",PKGDATADIR);
+            snprintf(filename,sizeof(filename),"%s/keymap",PKGDATADIR);
             f=fopen(filename,"r");
             if(f==NULL)
                return;
@@ -90,7 +90,7 @@ void SaveKeymap()
    char  filename[1024];
    FILE  *f;
 
-   sprintf(filename,"%s/.le/keymap",HOME);
+   snprintf(filename,sizeof(filename),"%s/.le/keymap",HOME);
    f=fopen(filename,"w");
    if(!f)
    {
@@ -105,7 +105,7 @@ void SaveKeymapForTerminal()
    char  filename[1024];
    FILE  *f;
 
-   sprintf(filename,"%s/.le/keymap-%s",HOME,TERM);
+   snprintf(filename,sizeof(filename),"%s/.le/keymap-%s",HOME,TERM);
    f=fopen(filename,"w");
    if(!f)
    {

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -90,7 +90,7 @@ int    LockFile(int fd,bool drop)
          }
          fstat(fd,&st);
 
-         sprintf(msg,"This file is already locked by process %ld",(long)Lock1.l_pid);
+         snprintf(msg,sizeof(msg),"This file is already locked by process %ld",(long)Lock1.l_pid);
          switch(ReadMenuBox(LockEnforce(st.st_mode)?
             LockMenu1:LockMenu,HORIZ,msg," Lock Error ",
 	    VERIFY_WIN_ATTR,CURR_BUTTON_ATTR))
@@ -233,7 +233,7 @@ int   LoadFile(char *name)
       return(OK);
    }
 
-   sprintf(msg,"Loading the file \"%.60s\"...",name);
+   snprintf(msg,sizeof(msg),"Loading the file \"%.60s\"...",name);
    MessageSync(msg);
 
    newfile=0;
@@ -425,27 +425,30 @@ int   LoadFile(char *name)
 
 int   MaxBackup=9;
 
-static char *BackupName(char *buf,char *bp,char *filename,char *bak,int n)
+static char *BackupName(char *buf,unsigned buf_size,char *bp,char *filename,char *bak,int n)
 {
-   char *suffix=(char*)alloca(strlen(bak)+40+1);
-   sprintf(suffix,bak,n);
-   sprintf(buf,"%s/%s%s",bp,filename,suffix);
+   unsigned nbytes=strlen(bak)+40+1;
+   char *suffix=(char*)alloca(nbytes);
+   snprintf(suffix,nbytes,bak,n);
+   snprintf(buf,buf_size,"%s/%s%s",bp,filename,suffix);
    return buf;
 }
 
 static void MoveBackup(char *bp,char *filename,char *bak,int n)
 {
-   char *bakname=(char*)alloca(strlen(bp)+1+strlen(filename)+strlen(bak)+40+1);
+   unsigned nbytes=strlen(bp)+1+strlen(filename)+strlen(bak)+40+1;
+   char *bakname=(char*)alloca(nbytes);
 
-   BackupName(bakname,bp,filename,bak,n);
+   BackupName(bakname,nbytes,bp,filename,bak,n);
    if(access(bakname,F_OK)!=-1)
    {
       if(n>=MaxBackup)
 	 remove(bakname);
       else
       {
-	 char *bakname1=(char*)alloca(strlen(bp)+1+strlen(filename)+strlen(bak)+40+1);
-	 BackupName(bakname1,bp,filename,bak,n+1);
+         unsigned nbytes1=strlen(bp)+1+strlen(filename)+strlen(bak)+40+1;
+	 char *bakname1=(char*)alloca(nbytes1);
+	 BackupName(bakname1,nbytes1,bp,filename,bak,n+1);
 	 if(!strcmp(bakname,bakname1))
 	    remove(bakname);
 	 else
@@ -496,18 +499,24 @@ static int CreateBak(char *name)
 
 
    char *bp=BakPath;
+   unsigned bp_size=sizeof(BakPath);
    if(*bp==0)
+   {
       bp=directory;
+      bp_size=sizeof(directory);
+   }
    else if(bp[0]=='~' && (bp[1]==0 || isslash(bp[1])))
    {
-      bp=(char*)alloca(strlen(bp)+strlen(HOME));
-      sprintf(bp,"%s%s",HOME,BakPath+1);
+      bp_size=strlen(bp)+strlen(HOME);
+      bp=(char*)alloca(bp_size);
+      snprintf(bp,bp_size,"%s%s",HOME,BakPath+1);
    }
 
    MoveBackup(bp,filename,bak,1);
 
-   char *bakname=(char*)alloca(strlen(bp)+1+strlen(filename)+strlen(bak)+40+1);
-   BackupName(bakname,bp,filename,bak,1);
+   unsigned nbytes=strlen(bp)+1+strlen(filename)+strlen(bak)+40+1;
+   char *bakname=(char*)alloca(nbytes);
+   BackupName(bakname,nbytes,bp,filename,bak,1);
 
    if(stat(name,&st)==-1)
    {
@@ -605,7 +614,7 @@ int   SaveFile(char *name)
    if(Text && !View)
       UserOptimizeText();
 
-   sprintf(msg,"Saving the file \"%.60s\"...",name);
+   snprintf(msg,sizeof(msg),"Saving the file \"%.60s\"...",name);
    MessageSync(msg);
 
    if(stat(name,&st)!=-1)

--- a/src/menu1.cc
+++ b/src/menu1.cc
@@ -247,8 +247,9 @@ void  FormatItemText(int n,int clear_len)
       right_text=tab+1;
    }
    int right_len=strlen(right_text);
-   char *new_text=(char*)malloc(len+clear_len+right_len+3);
-   sprintf(new_text," %.*s%*s ",len,old_text,clear_len+right_len,right_text);
+   unsigned nbytes=len+clear_len+right_len+3;
+   char *new_text=(char*)malloc(nbytes);
+   snprintf(new_text,nbytes," %.*s%*s ",len,old_text,clear_len+right_len,right_text);
    m[n].SetText(new_text);
 }
 
@@ -524,7 +525,7 @@ void LoadMainMenu()
    int mi=0;
    int level=0;
 
-   sprintf(fn,"%s/.le/mainmenu",HOME);
+   snprintf(fn,sizeof(fn),"%s/.le/mainmenu",HOME);
 
    f=fopen(fn,"r");
    if(f)

--- a/src/options.cc
+++ b/src/options.cc
@@ -324,9 +324,9 @@ void  SaveTermOpt()
    char  t[256];
    MessageSync("Saving the terminal options...");
 #ifndef MSDOS
-   sprintf(t,"%s/.le/term-%s",HOME,TERM);
+   snprintf(t,sizeof(t),"%s/.le/term-%s",HOME,TERM);
 #else
-   sprintf(t,"%s/le-%s",HOME,TERM);
+   snprintf(t,sizeof(t),"%s/le-%s",HOME,TERM);
 #endif
    SaveConfToFile(t,term);
    ClearMessage();
@@ -445,15 +445,15 @@ void  ReadConf()
 #ifndef __MSDOS__
    bool mine;
 
-   sprintf(t,"%s/.le/term-%s",HOME,TERM);
+   snprintf(t,sizeof(t),"%s/.le/term-%s",HOME,TERM);
    if(!ConfOK(t,false))
    {
-      sprintf(t,"%s/term-%s",PKGDATADIR,TERM);
+      snprintf(t,sizeof(t),"%s/term-%s",PKGDATADIR,TERM);
       if(!ConfOK(t,false))
       {
-	 sprintf(t,"%s/.le/term",HOME);
+	 snprintf(t,sizeof(t),"%s/.le/term",HOME);
 	 if(!ConfOK(t,false))
-            sprintf(t,"%s/term",PKGDATADIR);
+            snprintf(t,sizeof(t),"%s/term",PKGDATADIR);
       }
    }
    ReadConfFromFile(t,term,false);
@@ -461,15 +461,15 @@ void  ReadConf()
    if(chset[0]=='7') // workaround for older version
       init_chset();
 
-   sprintf(t,"%s/.le/colors-%s",HOME,TERM);
+   snprintf(t,sizeof(t),"%s/.le/colors-%s",HOME,TERM);
    if(!ConfOK(t,false))
    {
-      sprintf(t,"%s/colors-%s",PKGDATADIR,TERM);
+      snprintf(t,sizeof(t),"%s/colors-%s",PKGDATADIR,TERM);
       if(!ConfOK(t,false))
       {
-	 sprintf(t,"%s/.le/colors",HOME);
+	 snprintf(t,sizeof(t),"%s/.le/colors",HOME);
 	 if(!ConfOK(t,false))
-	    sprintf(t,"%s/colors",PKGDATADIR);
+	    snprintf(t,sizeof(t),"%s/colors",PKGDATADIR);
       }
    }
    ReadConfFromFile(t,colors,false);
@@ -481,10 +481,10 @@ void  ReadConf()
       strcpy(InitName,".le.ini");
       if(!ConfOK(InitName,mine=true))
       {
-	 sprintf(InitName,"%s/.le/le.ini",HOME);
+	 snprintf(InitName,sizeof(InitName),"%s/.le/le.ini",HOME);
 	 if(!ConfOK(InitName,mine=false))
 	 {
-	    sprintf(t,"%s/le.ini",PKGDATADIR);
+	    snprintf(t,sizeof(t),"%s/le.ini",PKGDATADIR);
 	    ReadConfFromFile(t,init,false);
 	    goto ini_done;
 	 }
@@ -495,11 +495,11 @@ void  ReadConf()
 ini_done:
 
 #else
-   sprintf(t,"%s/le-%s",HOME,TERM);
+   snprintf(t,sizeof(t),"%s/le-%s",HOME,TERM);
    ReadConfFromFile(t,term,false);
    strcpy(InitName,"le.ini");
    if(access(InitName,R_OK)==-1)
-     sprintf(InitName,"%s/le.ini",HOME);
+     snprintf(InitName,sizeof(InitName),"%s/le.ini",HOME);
    ReadConfFromFile(InitName,init,false);
 #endif
 
@@ -757,9 +757,9 @@ void  W_Dialogue(struct opt *opt,
             break;
          case(STR):
             if(p==curr)
-               sprintf(s,"%-*.*s",p->len,p->len,(char*)(p->var)+mb_get_pos_for_col((char*)(p->var),shift,strlen((char*)(p->var))));
+               snprintf(s,sizeof(s),"%-*.*s",p->len,p->len,(char*)(p->var)+mb_get_pos_for_col((char*)(p->var),shift,strlen((char*)(p->var))));
             else
-               sprintf(s,"%-*.*s",p->len,p->len,(char*)(p->var));
+               snprintf(s,sizeof(s),"%-*.*s",p->len,p->len,(char*)(p->var));
             if(curr==p)
                SetAttr(CURR_BUTTON_ATTR);
             PutStr(p->x,p->y,s);
@@ -768,7 +768,7 @@ void  W_Dialogue(struct opt *opt,
             DisplayItem(p->x,p->y,p->name,curr==p?CURR_BUTTON_ATTR:DIALOGUE_WIN_ATTR);
             break;
          case(NUM):
-            sprintf(s,"%-*d",(p->len?p->len:2),*(int*)(p->var));
+            snprintf(s,sizeof(s),"%-*d",(p->len?p->len:2),*(int*)(p->var));
             if(curr==p)
                SetAttr(CURR_BUTTON_ATTR);
             PutStr(p->x,p->y,s);

--- a/src/screen.cc
+++ b/src/screen.cc
@@ -342,9 +342,9 @@ void  StatusLine()
       else
       {
 	 if(MBCheckRight() && MBCharSize>1)
-	    sprintf(chr,"UC:%04X",WChar());
+	    snprintf(chr,sizeof(chr),"UC:%04X",WChar());
 	 else
-	    sprintf(chr,"Ch:%-3d",Char());
+	    snprintf(chr,sizeof(chr),"Ch:%-3d",Char());
       }
    }
 
@@ -357,20 +357,20 @@ void  StatusLine()
    if(View)
    {
       if(buffer_mmapped)
-	 sprintf(flags,"MM R/O %c",
+	 snprintf(flags,sizeof(flags),"MM R/O %c",
 	    rblock   ?'B':' ');
       else
-	 sprintf(flags,"R/O %c %c",
+	 snprintf(flags,sizeof(flags),"R/O %c %c",
 	    rblock   ?'B':' ',eol);
    }
    else
    {
       if(buffer_mmapped)
-	 sprintf(flags,"MM %c%c   ",
+	 snprintf(flags,sizeof(flags),"MM %c%c   ",
 	    inputmode   ?(inputmode==2?'G':'R'):' ',
 	    rblock	?'B':' ');
       else
-	 sprintf(flags,"%c%c%c%c%c%c%c",
+	 snprintf(flags,sizeof(flags),"%c%c%c%c%c%c%c",
 	    modified	?'*':' ',
 	    inputmode   ?(inputmode==2?'G':'R'):' ',
 	    insert	?'I':'O',
@@ -400,26 +400,27 @@ void  StatusLine()
       if(wname==0)
       {
 	 if(l>14)
-	    sprintf(name,"%.*s..%.*s",6,bn,6,bn+l-6);
+	    snprintf(name,sizeof(name),"%.*s..%.*s",6,bn,6,bn+l-6);
 	 else
 	    strcpy(name,bn);
       }
    }
    else
-      sprintf(name,"NewFile");
+      snprintf(name,sizeof(name),"NewFile");
 
 
    if(hex)
-      sprintf(status,"OctOffs:0%-11lo",(unsigned long)(Offset()));
+      snprintf(status,sizeof(status),"OctOffs:0%-11lo",(unsigned long)(Offset()));
    else
-      sprintf(status,"Line=%-5lu Col=%-4lu",
+      snprintf(status,sizeof(status),"Line=%-5lu Col=%-4lu",
 	 (unsigned long)(GetLine()+1),
 	 (unsigned long)(((Text&&Eol())?GetStdCol():GetCol())+1));
 
-   sprintf(status+strlen(status)," Sz:%-6lu %-7s %s",
+   unsigned status_len=strlen(status);
+   snprintf(status+status_len,sizeof(status)-status_len," Sz:%-6lu %-7s %s",
          (unsigned long)(Size()),chr,flags);
 
-   sprintf(status_right," Offs:%lu (%d%%)",(unsigned long)(Offset()),
+   snprintf(status_right,sizeof(status_right)," Offs:%lu (%d%%)",(unsigned long)(Offset()),
          (int)(Size()?(Offset()*100.+Size()/2)/Size():100));
 
    move(StatusLineY,0);
@@ -610,7 +611,7 @@ void  Redisplay(num line,offs ptr,num limit)
 
 	    if(!EofAt(ptr) || line==(Size()-ScreenTop.Offset()+15)/16)
 	    {
-	       sprintf(s,"%08lX   ",(unsigned long)ptr);
+	       snprintf(s,sizeof(s),"%08lX   ",(unsigned long)ptr);
 	       for(sp=s; *sp; sp++)
 		  *clp++=norm_attr->n_attr|*sp;
 	    }
@@ -618,7 +619,7 @@ void  Redisplay(num line,offs ptr,num limit)
 	    {
 	       if(EofAt(ptr))
 		  break;
-	       sprintf(s,"%02X",CharAt(ptr));
+	       snprintf(s,sizeof(s),"%02X",CharAt(ptr));
 	       ca=(InBlock(ptr)?blk_attr:norm_attr);
 	       if(ascii && ptr==Offset() && ShowMatchPos)
 		  ca=SHADOW_ATTR;
@@ -655,7 +656,7 @@ void  Redisplay(num line,offs ptr,num limit)
 	    clwp=clw;
 	    if(!EofAt(ptr) || line==(Size()-ScreenTop.Offset()+15)/16)
 	    {
-	       sprintf(s,"%08lX   ",(unsigned long)ptr);
+	       snprintf(s,sizeof(s),"%08lX   ",(unsigned long)ptr);
 	       for(sp=s; *sp; sp++)
 		  le_add_cchar(clwp,norm_attr->n_attr,*sp);
 	    }
@@ -663,7 +664,7 @@ void  Redisplay(num line,offs ptr,num limit)
 	    {
 	       if(EofAt(ptr))
 		  break;
-	       sprintf(s,"%02X",CharAt(ptr));
+	       snprintf(s,sizeof(s),"%02X",CharAt(ptr));
 	       ca=(InBlock(ptr)?blk_attr:norm_attr);
 	       if(ascii && ptr==Offset() && ShowMatchPos)
 		  ca=SHADOW_ATTR;
@@ -978,9 +979,9 @@ void  FError(const char *s)
    char  msg[256];
 
    if(strlen(s)>50)
-      sprintf(msg,"File: ...%s\n",s+strlen(s)-47);
+      snprintf(msg,sizeof(msg),"File: ...%s\n",s+strlen(s)-47);
    else
-      sprintf(msg,"File: %s\n",s);
+      snprintf(msg,sizeof(msg),"File: %s\n",s);
    strcat(msg,err);
 
    ErrMsg(msg);

--- a/src/search.cc
+++ b/src/search.cc
@@ -519,7 +519,7 @@ void  Replace()
             else if(rcnt==1)
                strcpy(str,"1 replacement.");
             else
-               sprintf(str,"%d replacements.",rcnt);
+               snprintf(str,sizeof(str),"%d replacements.",rcnt);
             if(key!='#')
                CurrentPos=back_tp;
             SetStdCol();

--- a/src/signals.cc
+++ b/src/signals.cc
@@ -139,7 +139,7 @@ static char mem[4000];
 char *TmpFileName()
 {
 #ifndef __MSDOS__
-   sprintf(mem,"%s/.le/tmp/",HOME);
+   snprintf(mem,sizeof(mem),"%s/.le/tmp/",HOME);
    char *add=mem+strlen(mem);
    strcpy(add,FileName);
    while(*add)
@@ -148,16 +148,16 @@ char *TmpFileName()
 	 *add='_';
       add++;
    }
-   sprintf(add,".%d",(int)getpid());
+   snprintf(add,mem+sizeof(mem)-add,".%d",(int)getpid());
 #else
-   sprintf(mem,"le%d.res",(int)getpid());
+   snprintf(mem,sizeof(mem),"le%d.res",(int)getpid());
 #endif
    return mem;
 }
 char *HupFileName(int sig)
 {
 #ifndef __MSDOS__
-   sprintf(mem,"%s/.le/tmp/DUMP-%d-",HOME,sig);
+   snprintf(mem,sizeof(mem),"%s/.le/tmp/DUMP-%d-",HOME,sig);
    char *add=mem+strlen(mem);
    strcpy(add,FileName);
    while(*add)
@@ -166,9 +166,9 @@ char *HupFileName(int sig)
 	 *add='_';
       add++;
    }
-   sprintf(add,".%d",(int)getpid());
+   snprintf(add,mem+sizeof(mem)-add,".%d",(int)getpid());
 #else
-   sprintf(mem,"le%d.hup",(int)getpid());
+   snprintf(mem,sizeof(mem),"le%d.hup",(int)getpid());
 #endif
    return mem;
 }

--- a/src/user.cc
+++ b/src/user.cc
@@ -970,13 +970,13 @@ int   file_check(const char *fn)
    {
       if(access(fn,F_OK)==0)
       {
-	 sprintf(msg,"File: %s\nThe specified file is not readable",fn);
+	 snprintf(msg,sizeof(msg),"File: %s\nThe specified file is not readable",fn);
 	 ErrMsg(msg);
 	 return ERR;
       }
       if((View&RO_MODE) || buffer_mmapped)  // view mode or mmap mode
       {
-	 sprintf(msg,"File: %s\nThe specified file does not exist",fn);
+	 snprintf(msg,sizeof(msg),"File: %s\nThe specified file does not exist",fn);
 	 ErrMsg(msg);
 	 return ERR;
       }
@@ -989,13 +989,13 @@ int   file_check(const char *fn)
 	 strcpy(dir,".");
       if(access(dir,F_OK)==-1)
       {
-	 sprintf(msg,"File: %s\nThe specified directory does not exist",fn);
+	 snprintf(msg,sizeof(msg),"File: %s\nThe specified directory does not exist",fn);
 	 ErrMsg(msg);
 	 return ERR;
       }
       if(access(dir,W_OK|X_OK)==-1)
       {
-	 sprintf(msg,"File: %s\nThe specified file does not exist\n"
+	 snprintf(msg,sizeof(msg),"File: %s\nThe specified file does not exist\n"
 		"and the directory does not permit creating",fn);
 	 ErrMsg(msg);
 	 return ERR;
@@ -1007,7 +1007,7 @@ int   file_check(const char *fn)
 	 {" &Cancel ",MIDDLE+6,4},
 	 {NULL}
       };
-      sprintf(msg,"The file `%s' does not exist. Create?",fn);
+      snprintf(msg,sizeof(msg),"The file `%s' does not exist. Create?",fn);
       switch(ReadMenuBox(CreateOrNot,HORIZ,msg,
 	 " Verify ",VERIFY_WIN_ATTR,CURR_BUTTON_ATTR))
       {
@@ -1027,7 +1027,7 @@ void    UserLoad()
 
    if(getstring("Load: ",newname,sizeof(newname)-1,&LoadHistory)>0)
    {
-      if(ChooseFileName(newname)<0)
+      if(ChooseFileName(newname,sizeof(newname))<0)
          return;
       if(file_check(newname)==ERR)
       {
@@ -1054,7 +1054,7 @@ int   UserSaveAs()
 
    if(getstring("Save as: ",newname,sizeof(newname)-1,&LoadHistory,NULL,NULL)>0)
    {
-      if(ChooseFileName(newname)<0)
+      if(ChooseFileName(newname,sizeof(newname))<0)
          return(ERR);
       if(SaveFile(newname)!=OK)
       {
@@ -1080,7 +1080,7 @@ void  UserSwitch()
    strncpy(newname,prev->get_line(),255);
    newname[255]=0;
 
-   if(ChooseFileName(newname)<0)
+   if(ChooseFileName(newname,sizeof(newname))<0)
       return;
 
    if(access(newname,R_OK)==-1)
@@ -1121,21 +1121,21 @@ void  UserInfo()
 
    do
    {
-      sprintf(s,"File: %.40s",FileName);
+      snprintf(s,sizeof(s),"File: %.40s",FileName);
       PutStr(3,cl=2,s);
 
-      sprintf(s,"Line=%-6ld Col=%-6ld\nSize:%-6ld Offset:%-6ld",(long)GetLine(),
+      snprintf(s,sizeof(s),"Line=%-6ld Col=%-6ld\nSize:%-6ld Offset:%-6ld",(long)GetLine(),
              (long)(Text&&Eol()?GetStdCol():GetCol()),(long)Size(),(long)Offset());
       PutStr(3,cl+=2,s);
 
-      sprintf(s,"CWD:  %.40s",cwd);
+      snprintf(s,sizeof(s),"CWD:  %.40s",cwd);
       PutStr(3,cl+=3,s);
 
       time(&t);
-      sprintf(s,"Date: %s",ctime(&t));
+      snprintf(s,sizeof(s),"Date: %s",ctime(&t));
       PutStr(3,cl+=1,s);
 
-      sprintf(s,"User: %s(%ld), Group: %s(%ld)",pw?pw->pw_name:"",(long)uid,
+      snprintf(s,sizeof(s),"User: %s(%ld), Group: %s(%ld)",pw?pw->pw_name:"",(long)uid,
                                               gr?gr->gr_name:"",(long)gid);
       PutStr(3,cl+=2,s);
 


### PR DESCRIPTION
Two changes:
- Use snprintf instead of sprintf, to avoid GCC warnings.
- Increase cmake version to 3.5, as previous versions are deprecated.